### PR TITLE
V1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [2022-08-16] v1.5.1
+## [2023-08-21] v1.5.2
+
+- 2fa7377 fix: use `jsxId` cache instead `resolved`
+
+## [2023-08-16] v1.5.1
 
 - 14cc294 feat: support switch AST
 

--- a/index.js
+++ b/index.js
@@ -62,8 +62,9 @@ module.exports = function langJsx(options = {}) {
             // User filter
             if (options.filter?.(resolved) === false) return;
 
-            jsxFileCache.set(source, resolved);
-            return toLangJsx(resolved);
+            const jsxId = toLangJsx(resolved);
+            jsxFileCache.set(source, jsxId);
+            return jsxId;
           }
         }
       } catch (e) { }
@@ -181,16 +182,16 @@ class AstExt {
 
   async checkJSX(content, useAst = false) {
     if (useAst) {
-      let isAst = false;
+      let jsJSX = false;
       const ast = this.acornExt.parse(content, { sourceType: 'module', ecmaVersion: 'latest' });
       this.deepWalk(ast, node => {
         if (['JSXElement', 'JSXFragment'].includes(node.type)) {
-          isAst = true;
+          jsJSX = true;
           return false;
         }
       });
 
-      return isAst;
+      return jsJSX;
     }
 
     // It's not rigorous enough, but the performance is high enough.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-lang-jsx",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Support write jsx in js files",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## [2023-08-21] v1.5.2

- 2fa7377 fix: use `jsxId` cache instead `resolved`